### PR TITLE
Allow to unregister a route

### DIFF
--- a/src/Route/RouteRegister.php
+++ b/src/Route/RouteRegister.php
@@ -62,6 +62,10 @@ final class RouteRegister
         );
 
         foreach ($routeData as $method => $routeDefinitionData) {
+            if ($routeDefinitionData === []) {
+                continue;
+            }
+
             $routeDefinition = $this->routeDefinitionFactory->create($method, $routeDefinitionData);
 
             $routeName = $routeDefinition->getName() ?? $resolveRoutePath;

--- a/src/Route/RouteRegister.php
+++ b/src/Route/RouteRegister.php
@@ -62,7 +62,7 @@ final class RouteRegister
         );
 
         foreach ($routeData as $method => $routeDefinitionData) {
-            if ($routeDefinitionData === []) {
+            if ($routeDefinitionData === $this->getEmptyRouteDefinitionData()) {
                 continue;
             }
 
@@ -105,5 +105,20 @@ final class RouteRegister
             $versionMiddlewares,
             $this->beforeRouteMiddlewares->getMiddlewares()
         );
+    }
+
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getEmptyRouteDefinitionData(): array
+    {
+        return [
+            RouteDefinition::SERVICE => null,
+            RouteDefinition::MIDDLEWARES => [],
+            RouteDefinition::MIDDLEWARE_GROUPS => [],
+            RouteDefinition::IGNORE_VERSION_MIDDLEWARE_GROUP => false,
+            RouteDefinition::NAME => null,
+        ];
     }
 }

--- a/tests/Sample/ListChannelsRoute.php
+++ b/tests/Sample/ListChannelsRoute.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyTest\Slim\Sample;
+
+use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\ResponseInterface;
+use BrandEmbassy\Slim\Route\Route;
+
+final class ListChannelsRoute implements Route
+{
+    /**
+     * @param string[] $arguments
+     */
+    public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        return $response->withJson(
+            [
+                [
+                    'id' => 1,
+                    'name' => 'First channel',
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Second channel',
+                ],
+            ],
+            200
+        );
+    }
+}

--- a/tests/SlimApplicationFactoryTest.php
+++ b/tests/SlimApplicationFactoryTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Slim\Router;
 use function assert;
+use function count;
 
 final class SlimApplicationFactoryTest extends TestCase
 {
@@ -172,6 +173,22 @@ final class SlimApplicationFactoryTest extends TestCase
         $response = SlimAppTester::runSlimApp(__DIR__ . '/no-prefix-config.neon');
 
         ResponseAssertions::assertResponseHeaders($expectedHeaders, $response);
+    }
+
+
+    public function testRouteCanBeUnregistered(): void
+    {
+        $slimAppWithAllRoutes = SlimAppTester::createSlimApp(__DIR__ . '/config.neon');
+        $routerWithAllRoutes = $slimAppWithAllRoutes->getContainer()->get('router');
+        assert($routerWithAllRoutes instanceof Router);
+
+        $slimAppWithUnregisteredRoute = SlimAppTester::createSlimApp(__DIR__ . '/unregister-route-config.neon');
+        $routerWithUnregisteredRoute = $slimAppWithUnregisteredRoute->getContainer()->get('router');
+        assert($routerWithUnregisteredRoute instanceof Router);
+
+        $expectedRouteCount = count($routerWithAllRoutes->getRoutes()) - 1;
+
+        Assert::assertCount($expectedRouteCount, $routerWithUnregisteredRoute->getRoutes());
     }
 
 

--- a/tests/SlimApplicationFactoryTest.php
+++ b/tests/SlimApplicationFactoryTest.php
@@ -117,6 +117,18 @@ final class SlimApplicationFactoryTest extends TestCase
                 'requestUri' => '/tests/api/channels',
                 'headers' => ['HTTP_X_API_KEY' => GoldenKeyAuthMiddleware::ACCESS_TOKEN],
             ],
+            'Get channel list' => [
+                'expectedResponse' => [['id' => 1, 'name' => 'First channel'], ['id' => 2, 'name' => 'Second channel']],
+                'expectedResponseHeaders' => [
+                    BeforeRequestMiddleware::HEADER_NAME => 'invoked-0',
+                    BeforeRouteMiddleware::HEADER_NAME => 'invoked-1',
+                    OnlyApiGroupMiddleware::HEADER_NAME => 'invoked-2',
+                    GroupMiddleware::HEADER_NAME => 'invoked-3',
+                ],
+                'expectedStatusCode' => 200,
+                'httpMethod' => 'GET',
+                'requestUri' => '/tests/api/channels',
+            ],
         ];
     }
 

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -8,6 +8,7 @@ services:
     - BrandEmbassyTest\Slim\Sample\ApiErrorHandler
     - BrandEmbassyTest\Slim\Sample\GoldenKeyAuthMiddleware
     - BrandEmbassyTest\Slim\Sample\CreateChannelRoute
+    - BrandEmbassyTest\Slim\Sample\ListChannelsRoute
     - BrandEmbassyTest\Slim\Sample\ErrorThrowingRoute
     - BrandEmbassyTest\Slim\Sample\BeforeRequestMiddleware
     - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
@@ -44,6 +45,10 @@ slimApi:
 
         "api":
             '/channels':
+                get:
+                    service: BrandEmbassyTest\Slim\Sample\ListChannelsRoute
+                    middlewareGroups:
+                        - testGroup
                 post:
                     service: BrandEmbassyTest\Slim\Sample\CreateChannelRoute
                     middlewares:

--- a/tests/unregister-route-config.neon
+++ b/tests/unregister-route-config.neon
@@ -1,0 +1,8 @@
+includes:
+    - config.neon
+
+slimApi:
+    routes:
+        "api":
+            "/channels":
+                post!: null


### PR DESCRIPTION
There was no nice way in the current way of registering routes to disable a certain method.

You need to override the whole route config to eg. disallow POST:

base config:
```neon
slim:
  routes:
    'app':
      'some-slug':
        get:
          service: SomeService
          middlewares: [...someMiddlewares]
        post:
          service: SomeService
          middlewares: [...someMiddlewares]
```

overriding config:
```neon
slim:
  routes:
    'app':
      'some-slug!':
        get:
          service: SomeService
          middlewares: [...someMiddlewares]
```

This leads to repetition and if the base middleware config were to change, you would need to change it in all overriding configs (leading to mistakes).

Imo it should be possible to provide an empty array to disable a route:

suggested overriding config:
```neon
slim:
  routes:
    'app':
      'some-slug':
        post!:
```
