### PR TITLE
Attempt to fix the issue with HTTP/2 and long responses

### DIFF
--- a/src/SlimApp.php
+++ b/src/SlimApp.php
@@ -18,7 +18,7 @@ class SlimApp extends App
      */
     public function run($silent = false): ResponseInterface
     {
-        $response = parent::run($silent);
+        $response = parent::run(true);
 
         $contentTypes = $response->getHeader('Content-Type');
         $contentType = reset($contentTypes);


### PR DESCRIPTION
Issue seemed to be caused by calling `$this->respond($response)` twice in the `SlimApp::run()` method (once in the method body itself, once in the parent method).

Content length was correct, but some clients ignored it (depending on the HTTP/2 setting and infrastructure details), causing the content to appear twice.