### PR TITLE
Add afterRouteMiddlewares configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ slimApi:
         - App\SomeBeforeRouteMiddleware 
         
     afterRouteMiddlewares:
-      # this is called for each route, after the route middlewares
-      - App\SomeAfterRouteMiddleware
+        # this is called for each route, after the route middlewares
+        - App\SomeAfterRouteMiddleware
 
     beforeRequestMiddlewares:
         # this is called for each request, even when route does NOT exist (404 requests)

--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ slimApi:
                         - App\UsuallyRequestDataValidationMiddleware # second in row
                         - App\SomeAuthMiddleware # this one is called first 
 
-        afterRouteMiddlewares:
-            # this is called for each route, after the route middlewares
-            - App\SomeAfterRequestMiddleware 
+    beforeRouteMiddlewares:
+        # this is called for each route, before route middlewares
+        - App\SomeBeforeRouteMiddleware 
+        
+    afterRouteMiddlewares:
+      # this is called for each route, after the route middlewares
+      - App\SomeAfterRouteMiddleware
 
-        beforeRouteMiddlewares:
-            # this is called for each route, before route middlewares
-            - App\SomeBeforeRequestMiddleware 
-            
-        beforeRequestMiddlewares:
-            # this is called for each request, even when route does NOT exist (404 requests)
-            - App\SomeBeforeRouteMiddleware tests/Dummy/BeforeRequestMiddleware.php
+    beforeRequestMiddlewares:
+        # this is called for each request, even when route does NOT exist (404 requests)
+        - App\SomeBeforeRequestMiddleware
 ```
 
 You can also reference the named service by its name.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,17 @@ slimApi:
                         - App\UsuallyRequestDataValidationMiddleware # second in row
                         - App\SomeAuthMiddleware # this one is called first 
 
-    beforeRouteMiddlewares:
-        # this is called for each route, before route middlewares
-        - App\SomeBeforeRouteMiddleware 
-        
-    beforeRequestMiddlewares:
-        # this is called for each request, even when route does NOT exist (404 requests)
-        - App\SomeBeforeRequestMiddleware
+        afterRouteMiddlewares:
+            # this is called for each route, after the route middlewares
+            - App\SomeAfterRequestMiddleware 
+
+        beforeRouteMiddlewares:
+            # this is called for each route, before route middlewares
+            - App\SomeBeforeRequestMiddleware 
+            
+        beforeRequestMiddlewares:
+            # this is called for each request, even when route does NOT exist (404 requests)
+            - App\SomeBeforeRouteMiddleware tests/Dummy/BeforeRequestMiddleware.php
 ```
 
 You can also reference the named service by its name.

--- a/src/DI/SlimApiExtension.php
+++ b/src/DI/SlimApiExtension.php
@@ -2,6 +2,7 @@
 
 namespace BrandEmbassy\Slim\DI;
 
+use BrandEmbassy\Slim\Middleware\AfterRouteMiddlewares;
 use BrandEmbassy\Slim\Middleware\BeforeRouteMiddlewares;
 use BrandEmbassy\Slim\Middleware\MiddlewareFactory;
 use BrandEmbassy\Slim\Middleware\MiddlewareGroups;
@@ -55,6 +56,8 @@ class SlimApiExtension extends CompilerExtension
                     ->default([]),
                 SlimApplicationFactory::BEFORE_ROUTE_MIDDLEWARES => Expect::arrayOf($this->createServiceExpect())
                     ->default([]),
+                SlimApplicationFactory::AFTER_ROUTE_MIDDLEWARES => Expect::arrayOf($this->createServiceExpect())
+                    ->default([]),
                 SlimApplicationFactory::SLIM_CONFIGURATION => Expect::array()->default([]),
                 SlimApplicationFactory::API_PREFIX => Expect::string()->default(''),
                 SlimApplicationFactory::MIDDLEWARE_GROUPS => Expect::arrayOf(
@@ -76,6 +79,9 @@ class SlimApiExtension extends CompilerExtension
 
         $builder->addDefinition($this->prefix('beforeRouteMiddlewares'))
             ->setFactory(BeforeRouteMiddlewares::class, [$config[SlimApplicationFactory::BEFORE_ROUTE_MIDDLEWARES]]);
+
+        $builder->addDefinition($this->prefix('afterRouteMiddlewares'))
+            ->setFactory(AfterRouteMiddlewares::class, [$config[SlimApplicationFactory::AFTER_ROUTE_MIDDLEWARES]]);
 
         $builder->addDefinition($this->prefix('middlewareGroups'))
             ->setFactory(MiddlewareGroups::class, [$config[SlimApplicationFactory::MIDDLEWARE_GROUPS]]);

--- a/src/Middleware/AfterRouteMiddlewares.php
+++ b/src/Middleware/AfterRouteMiddlewares.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\Slim\Middleware;
+
+/**
+ * @final
+ */
+class AfterRouteMiddlewares
+{
+    /**
+     * @var callable[]
+     */
+    private array $middlewares;
+
+
+    /**
+     * @param string[] $afterRouteMiddlewares
+     */
+    public function __construct(array $afterRouteMiddlewares, MiddlewareFactory $middlewareFactory)
+    {
+        $this->middlewares = $middlewareFactory->createFromIdentifiers($afterRouteMiddlewares);
+    }
+
+
+    /**
+     * @return callable[]
+     */
+    public function getMiddlewares(): array
+    {
+        return $this->middlewares;
+    }
+}

--- a/src/Route/RouteRegister.php
+++ b/src/Route/RouteRegister.php
@@ -2,6 +2,7 @@
 
 namespace BrandEmbassy\Slim\Route;
 
+use BrandEmbassy\Slim\Middleware\AfterRouteMiddlewares;
 use BrandEmbassy\Slim\Middleware\BeforeRouteMiddlewares;
 use BrandEmbassy\Slim\Middleware\MiddlewareGroups;
 use Slim\Interfaces\RouterInterface;
@@ -22,6 +23,8 @@ class RouteRegister
 
     private BeforeRouteMiddlewares $beforeRouteMiddlewares;
 
+    private AfterRouteMiddlewares $afterRouteMiddlewares;
+
     private MiddlewareGroups $middlewareGroups;
 
 
@@ -30,12 +33,14 @@ class RouteRegister
         RouteDefinitionFactory $routeDefinitionFactory,
         UrlPatternResolver $urlPatternResolver,
         BeforeRouteMiddlewares $beforeRouteMiddlewares,
+        AfterRouteMiddlewares $afterRouteMiddlewares,
         MiddlewareGroups $middlewareGroups
     ) {
         $this->router = $router;
         $this->routeDefinitionFactory = $routeDefinitionFactory;
         $this->urlPatternResolver = $urlPatternResolver;
         $this->beforeRouteMiddlewares = $beforeRouteMiddlewares;
+        $this->afterRouteMiddlewares = $afterRouteMiddlewares;
         $this->middlewareGroups = $middlewareGroups;
     }
 
@@ -98,6 +103,7 @@ class RouteRegister
         );
 
         return array_merge_recursive(
+            $this->afterRouteMiddlewares->getMiddlewares(),
             $routeDefinition->getMiddlewares(),
             $middlewaresFromGroups,
             $versionMiddlewares,

--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -63,6 +63,11 @@ class SlimApplicationFactory
 
     private OnlyNecessaryRoutesProvider $onlyNecessaryRoutesProvider;
 
+    /**
+     * @var array<Middleware>
+     */
+    private array $afterRoutesMiddlewares = [];
+
 
     /**
      * @param mixed[] $configuration
@@ -109,6 +114,8 @@ class SlimApplicationFactory
             SlimSettings::ROUTE_API_NAMES_ALWAYS_INCLUDE,
             [],
         );
+
+        $this->registerAfterRouteMiddlewares($app, $configuration);
 
         if ($useApcuCache && !apcu_enabled()) {
             // @intentionally For cli scripts is APCU disabled by default

--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -31,6 +31,8 @@ class SlimApplicationFactory
 
     public const BEFORE_ROUTE_MIDDLEWARES = 'beforeRouteMiddlewares';
 
+    public const AFTER_ROUTE_MIDDLEWARES = 'afterRouteMiddlewares';
+
     public const HANDLERS = 'handlers';
 
     public const BEFORE_REQUEST_MIDDLEWARES = 'beforeRequestMiddlewares';
@@ -62,11 +64,6 @@ class SlimApplicationFactory
     private RouteRegister $routeRegister;
 
     private OnlyNecessaryRoutesProvider $onlyNecessaryRoutesProvider;
-
-    /**
-     * @var array<Middleware>
-     */
-    private array $afterRoutesMiddlewares = [];
 
 
     /**
@@ -114,8 +111,6 @@ class SlimApplicationFactory
             SlimSettings::ROUTE_API_NAMES_ALWAYS_INCLUDE,
             [],
         );
-
-        $this->registerAfterRouteMiddlewares($app, $configuration);
 
         if ($useApcuCache && !apcu_enabled()) {
             // @intentionally For cli scripts is APCU disabled by default

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -20,13 +20,23 @@ use function urlencode;
 class RequestTest extends TestCase
 {
     private const PARAM_NAME = 'dateFrom';
-    
+
     private const DATE_TIME_STRING = '2017-06-10T01:00:00+01:00';
-    
+
     private const CHANNEL_ID = '123';
 
 
     public function testShouldDistinguishBetweenNullAndEmptyOption(): void
+    {
+        $request = $this->getDispatchedRequest();
+
+        Assert::assertTrue($request->hasField('thisIsNull'));
+        Assert::assertFalse($request->hasField('nonExistingField'));
+        Assert::assertTrue($request->hasField('thisIsGandalf'));
+    }
+
+
+    public function testGetParsedBodyAsArray(): void
     {
         $request = $this->getDispatchedRequest();
 

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -20,23 +20,13 @@ use function urlencode;
 class RequestTest extends TestCase
 {
     private const PARAM_NAME = 'dateFrom';
-
+    
     private const DATE_TIME_STRING = '2017-06-10T01:00:00+01:00';
-
+    
     private const CHANNEL_ID = '123';
 
 
     public function testShouldDistinguishBetweenNullAndEmptyOption(): void
-    {
-        $request = $this->getDispatchedRequest();
-
-        Assert::assertTrue($request->hasField('thisIsNull'));
-        Assert::assertFalse($request->hasField('nonExistingField'));
-        Assert::assertTrue($request->hasField('thisIsGandalf'));
-    }
-
-
-    public function testGetParsedBodyAsArray(): void
     {
         $request = $this->getDispatchedRequest();
 

--- a/tests/Sample/AfterRouteMiddleware.php
+++ b/tests/Sample/AfterRouteMiddleware.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyTest\Slim\Sample;
+
+use BrandEmbassy\Slim\Middleware;
+use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\ResponseInterface;
+
+class AfterRouteMiddleware implements Middleware
+{
+    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
+    {
+        $response = $response->withHeader(
+            'header-to-be-changed-by-after-route-middleware',
+            'changed-value'
+        );
+
+        return $next($request, $response);
+    }
+}

--- a/tests/Sample/AfterRouteMiddleware.php
+++ b/tests/Sample/AfterRouteMiddleware.php
@@ -2,19 +2,23 @@
 
 namespace BrandEmbassyTest\Slim\Sample;
 
-use BrandEmbassy\Slim\Middleware;
+use BrandEmbassy\Slim\Middleware\Middleware;
 use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
+use BrandEmbassyTest\Slim\MiddlewareInvocationCounter;
 
+/**
+ * @final
+ */
 class AfterRouteMiddleware implements Middleware
 {
+    public const HEADER_NAME = 'after-route-middleware';
+
+
     public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
     {
-        $response = $response->withHeader(
-            'header-to-be-changed-by-after-route-middleware',
-            'changed-value'
-        );
+        $responseWithCounterHeader = MiddlewareInvocationCounter::invoke(self::HEADER_NAME, $response);
 
-        return $next($request, $response);
+        return $next($request, $responseWithCounterHeader);
     }
 }

--- a/tests/Sample/BeforeRouteMiddleware.php
+++ b/tests/Sample/BeforeRouteMiddleware.php
@@ -14,6 +14,15 @@ class BeforeRouteMiddleware implements Middleware
 
     public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
     {
+        $response = $response->withAddedHeader(
+            'header-to-be-changed-by-after-route-middleware',
+            'initial-value'
+        );
+        $response = $response->withAddedHeader(
+            'processed-by-before-route-middlewares',
+            'proof-for-before-route'
+        );
+
         $newResponse = MiddlewareInvocationCounter::invoke(self::HEADER_NAME, $response);
 
         return $next($request, $newResponse);

--- a/tests/Sample/BeforeRouteMiddleware.php
+++ b/tests/Sample/BeforeRouteMiddleware.php
@@ -7,6 +7,9 @@ use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use BrandEmbassyTest\Slim\MiddlewareInvocationCounter;
 
+/**
+ * @final
+ */
 class BeforeRouteMiddleware implements Middleware
 {
     public const HEADER_NAME = 'before-route-middleware';
@@ -14,17 +17,8 @@ class BeforeRouteMiddleware implements Middleware
 
     public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
     {
-        $response = $response->withAddedHeader(
-            'header-to-be-changed-by-after-route-middleware',
-            'initial-value'
-        );
-        $response = $response->withAddedHeader(
-            'processed-by-before-route-middlewares',
-            'proof-for-before-route'
-        );
+        $responseWithCounterHeader = MiddlewareInvocationCounter::invoke(self::HEADER_NAME, $response);
 
-        $newResponse = MiddlewareInvocationCounter::invoke(self::HEADER_NAME, $response);
-
-        return $next($request, $newResponse);
+        return $next($request, $responseWithCounterHeader);
     }
 }

--- a/tests/SlimApplicationFactoryTest.php
+++ b/tests/SlimApplicationFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace BrandEmbassyTest\Slim;
 
+use BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware;
 use BrandEmbassyTest\Slim\Sample\BeforeRequestMiddleware;
 use BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware;
 use BrandEmbassyTest\Slim\Sample\GoldenKeyAuthMiddleware;
@@ -64,6 +65,7 @@ class SlimApplicationFactoryTest extends TestCase
                     BeforeRequestMiddleware::HEADER_NAME => 'invoked-0',
                     BeforeRouteMiddleware::HEADER_NAME => 'invoked-1',
                     GroupMiddleware::HEADER_NAME => 'invoked-2',
+                    AfterRouteMiddleware::HEADER_NAME => 'invoked-3',
                 ],
                 'expectedStatusCode' => 200,
                 'httpMethod' => 'GET',
@@ -75,6 +77,7 @@ class SlimApplicationFactoryTest extends TestCase
                     BeforeRequestMiddleware::HEADER_NAME => 'invoked-0',
                     BeforeRouteMiddleware::HEADER_NAME => 'invoked-1',
                     GroupMiddleware::HEADER_NAME => 'invoked-2',
+                    AfterRouteMiddleware::HEADER_NAME => 'invoked-3',
                 ],
                 'expectedStatusCode' => 200,
                 'httpMethod' => 'GET',
@@ -115,6 +118,7 @@ class SlimApplicationFactoryTest extends TestCase
                     BeforeRouteMiddleware::HEADER_NAME => 'invoked-1',
                     OnlyApiGroupMiddleware::HEADER_NAME => 'invoked-2',
                     GroupMiddleware::HEADER_NAME => 'invoked-3',
+                    AfterRouteMiddleware::HEADER_NAME => 'invoked-4',
                 ],
                 'expectedStatusCode' => 201,
                 'httpMethod' => 'POST',
@@ -128,6 +132,7 @@ class SlimApplicationFactoryTest extends TestCase
                     BeforeRouteMiddleware::HEADER_NAME => 'invoked-1',
                     OnlyApiGroupMiddleware::HEADER_NAME => 'invoked-2',
                     GroupMiddleware::HEADER_NAME => 'invoked-3',
+                    AfterRouteMiddleware::HEADER_NAME => 'invoked-4',
                 ],
                 'expectedStatusCode' => 200,
                 'httpMethod' => 'GET',

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -16,6 +16,7 @@ services:
     - BrandEmbassyTest\Slim\Sample\GroupMiddleware
     - BrandEmbassyTest\Slim\Sample\OnlyApiGroupMiddleware
     helloWorldRoute: BrandEmbassyTest\Slim\Sample\HelloWorldRoute
+    - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
 
 slimApi:
     apiPrefix: '/tests'
@@ -75,8 +76,11 @@ slimApi:
         api:
             - BrandEmbassyTest\Slim\Sample\OnlyApiGroupMiddleware
 
-    beforeRouteMiddlewares:
-        - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
+        afterRouteMiddlewares:
+            - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
+
+        beforeRouteMiddlewares:
+            - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
 
     beforeRequestMiddlewares:
         - BrandEmbassyTest\Slim\Sample\BeforeRequestMiddleware

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -12,11 +12,11 @@ services:
     - BrandEmbassyTest\Slim\Sample\ErrorThrowingRoute
     - BrandEmbassyTest\Slim\Sample\BeforeRequestMiddleware
     - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
+    - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
     - BrandEmbassyTest\Slim\Sample\CreateChannelUserRoute
     - BrandEmbassyTest\Slim\Sample\GroupMiddleware
     - BrandEmbassyTest\Slim\Sample\OnlyApiGroupMiddleware
     helloWorldRoute: BrandEmbassyTest\Slim\Sample\HelloWorldRoute
-    - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
 
 slimApi:
     apiPrefix: '/tests'
@@ -76,11 +76,11 @@ slimApi:
         api:
             - BrandEmbassyTest\Slim\Sample\OnlyApiGroupMiddleware
 
-        afterRouteMiddlewares:
-            - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
+    beforeRouteMiddlewares:
+        - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
 
-        beforeRouteMiddlewares:
-            - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
+    afterRouteMiddlewares:
+        - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
 
     beforeRequestMiddlewares:
         - BrandEmbassyTest\Slim\Sample\BeforeRequestMiddleware


### PR DESCRIPTION
This PR adds the `afterRouteMiddlewares` configuration option to slim-nette-extension.

## Changes
- Added `afterRouteMiddlewares` configuration option
- Updated README with documentation
- Added test coverage for the new functionality
- Fixed phpstan issues

## Context
This branch is based on commit `27613f47857b0c4ed49904a9ef20ad59c5b4a6a3` which adds support for middleware execution after route handling.

Original PR: #64

## Testing
- ✅ Added `AfterRouteMiddleware` test sample
- ✅ Updated configuration tests
- ✅ PHPStan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)