### PR TITLE
Address review feedback: SlimContainer improvements and dead code removal

### DIFF
--- a/src/ServiceNotFoundException.php
+++ b/src/ServiceNotFoundException.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\Slim;
+
+use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
+use Throwable;
+use function sprintf;
+
+/**
+ * @final
+ */
+class ServiceNotFoundException extends RuntimeException implements NotFoundExceptionInterface
+{
+    public static function fromPrevious(string $id, Throwable $previous): self
+    {
+        return new self(
+            sprintf("Service '%s' not found in container.", $id),
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -10,7 +10,6 @@ use BrandEmbassy\Slim\Route\OnlyNecessaryRoutesProvider;
 use BrandEmbassy\Slim\Route\RouteRegister;
 use LogicException;
 use Nette\DI\Container;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\HttpMethodNotAllowedException;
@@ -104,11 +103,6 @@ class SlimApplicationFactory
             SlimSettings::USE_APCU_CACHE,
             true,
         );
-        $disableUsingSlimContainer = (bool)$this->getSlimSettings(
-            SlimSettings::DISABLE_USING_SLIM_CONTAINER,
-            false,
-        );
-
         $routeApiNamesAlwaysInclude = (array)$this->getSlimSettings(
             SlimSettings::ROUTE_API_NAMES_ALWAYS_INCLUDE,
             [],
@@ -117,10 +111,6 @@ class SlimApplicationFactory
         if ($useApcuCache && (!function_exists('apcu_enabled') || !apcu_enabled())) {
             // @intentionally For cli scripts is APCU disabled by default or extension not installed
             $useApcuCache = false;
-        }
-
-        if ($disableUsingSlimContainer && !($this->container instanceof ContainerInterface)) {
-            throw new LogicException('Container must be instance of \Psr\Container\ContainerInterface');
         }
 
         $slimContainer = new SlimContainer($this->container);

--- a/src/SlimContainer.php
+++ b/src/SlimContainer.php
@@ -3,7 +3,9 @@
 namespace BrandEmbassy\Slim;
 
 use Nette\DI\Container;
+use Nette\DI\MissingServiceException;
 use Psr\Container\ContainerInterface;
+use function array_key_exists;
 
 /**
  * @final
@@ -38,7 +40,15 @@ class SlimContainer implements ContainerInterface
      */
     public function get($id): mixed
     {
-        return $this->services[$id] ?? $this->netteContainer->getService($id);
+        if (array_key_exists($id, $this->services)) {
+            return $this->services[$id];
+        }
+
+        try {
+            return $this->netteContainer->getService($id);
+        } catch (MissingServiceException $e) {
+            throw ServiceNotFoundException::fromPrevious($id, $e);
+        }
     }
 
 
@@ -47,7 +57,7 @@ class SlimContainer implements ContainerInterface
      */
     public function has($id): bool
     {
-        if (isset($this->services[$id])) {
+        if (array_key_exists($id, $this->services)) {
             return true;
         }
 

--- a/src/SlimSettings.php
+++ b/src/SlimSettings.php
@@ -13,7 +13,5 @@ class SlimSettings
 
     public const USE_APCU_CACHE = 'useApcuCache';
 
-    public const DISABLE_USING_SLIM_CONTAINER = 'disableUsingSlimContainer';
-
     public const ROUTE_API_NAMES_ALWAYS_INCLUDE = 'routeApiNamesAlwaysInclude';
 }


### PR DESCRIPTION
Description: Improve SlimContainer null handling, add PSR-11 exception compliance, remove dead disableUsingSlimContainer setting
Possible impact: Container service resolution, error handling

---

## Summary

Addresses code review feedback on the Slim 3 compatibility cleanup (PR #87) with targeted improvements to `SlimContainer` and removal of dead code.

### Changes

**SlimContainer** (`src/SlimContainer.php`)
- Fix `get()`: Use `array_key_exists` instead of null-coalescing `??` so `null` services are correctly returned
- Fix `has()`: Use `array_key_exists` instead of `isset` so `null` services are correctly detected
- Add PSR-11 exception compliance: Wrap Nette's `MissingServiceException` in `ServiceNotFoundException`

**ServiceNotFoundException** (`src/ServiceNotFoundException.php`) - NEW
- Implements `Psr\Container\NotFoundExceptionInterface` as required by PSR-11
- Wraps original Nette exception as `$previous` for debugging

**Dead code removal**
- `SlimApplicationFactory`: Removed `disableUsingSlimContainer` setting read and validation (no longer has any effect after cleanup)
- `SlimSettings`: Removed `DISABLE_USING_SLIM_CONTAINER` constant

### Verification
- All 26 tests pass (110 assertions)
- PHPStan: 0 errors on changed files
- ECS: 0 violations on changed files

Generated with [Claude Code](https://claude.com/claude-code)