### PR TITLE
DE-154553: Add dual constructor and getInnerResponse to Response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "brandembassy/coding-standard": "^14.3",
+        "guzzlehttp/psr7": "^2.8",
         "marc-mabe/php-enum-phpstan": "^3.0",
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^11.5",

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -4,8 +4,14 @@ namespace BrandEmbassy\Slim\Response;
 
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Slim\Http\Headers;
 use Slim\Http\Response as SlimResponse;
+use Slim\Http\StatusCode;
+use Slim\Interfaces\Http\HeadersInterface;
 use function assert;
+use function implode;
 use function is_array;
 
 /**
@@ -13,6 +19,35 @@ use function is_array;
  */
 class Response extends SlimResponse implements ResponseInterface
 {
+    /**
+     * Creates a new Response instance.
+     *
+     * Supports two construction modes:
+     * - Legacy (Slim 3): new Response(200, $headers, $body)
+     * - PSR-7 wrapping:  new Response($psrResponse)
+     *
+     * The PSR-7 wrapping mode enables gradual migration to Slim 4 by allowing
+     * callers to construct Response from any PSR-7 response instance.
+     */
+    public function __construct(
+        PsrResponseInterface|int $statusOrResponse = StatusCode::HTTP_OK,
+        ?HeadersInterface $headers = null,
+        ?StreamInterface $body = null,
+    ) {
+        if ($statusOrResponse instanceof PsrResponseInterface) {
+            parent::__construct(
+                $statusOrResponse->getStatusCode(),
+                new Headers($this->flattenHeaders($statusOrResponse->getHeaders())),
+                $statusOrResponse->getBody(),
+            );
+
+            return;
+        }
+
+        parent::__construct($statusOrResponse, $headers, $body);
+    }
+
+
     /**
      * @return mixed[]
      *
@@ -24,5 +59,30 @@ class Response extends SlimResponse implements ResponseInterface
         assert(is_array($parsedBody));
 
         return $parsedBody;
+    }
+
+
+    public function getInnerResponse(): PsrResponseInterface
+    {
+        return $this;
+    }
+
+
+    /**
+     * Flattens PSR-7 headers (string[][]) to string[] for Slim 3 Headers constructor.
+     *
+     * @param string[][] $headers
+     *
+     * @return string[]
+     */
+    private function flattenHeaders(array $headers): array
+    {
+        $flattened = [];
+
+        foreach ($headers as $name => $values) {
+            $flattened[$name] = implode(', ', $values);
+        }
+
+        return $flattened;
     }
 }

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -29,4 +29,15 @@ interface ResponseInterface extends PsrResponseInterface
      * @return mixed[]
      */
     public function getParsedBodyAsArray(): array;
+
+
+    /**
+     * Returns the underlying PSR-7 response instance.
+     *
+     * This method enables gradual migration from Slim 3 to Slim 4. In the current
+     * Slim 3 implementation, the Response itself IS a PSR-7 response, so this
+     * simply returns $this. After migration to Slim 4 (composition-based), this
+     * will return the wrapped PSR-7 response.
+     */
+    public function getInnerResponse(): PsrResponseInterface;
 }

--- a/tests/Response/ResponseTest.php
+++ b/tests/Response/ResponseTest.php
@@ -3,8 +3,10 @@
 namespace BrandEmbassyTest\Slim\Response;
 
 use BrandEmbassy\Slim\Response\Response;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Slim\Http\StatusCode;
 
 /**
  * @final
@@ -16,6 +18,62 @@ class ResponseTest extends TestCase
         $parsedBody = ['foo' => 'bar'];
         $response = new Response();
         $response = $response->withJson($parsedBody);
+
+        Assert::assertSame($parsedBody, $response->getParsedBodyAsArray());
+    }
+
+
+    public function testLegacyConstructorWithDefaults(): void
+    {
+        $response = new Response();
+
+        Assert::assertSame(StatusCode::HTTP_OK, $response->getStatusCode());
+    }
+
+
+    public function testLegacyConstructorWithStatus(): void
+    {
+        $response = new Response(StatusCode::HTTP_NOT_FOUND);
+
+        Assert::assertSame(StatusCode::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+
+    public function testConstructorWithPsrResponse(): void
+    {
+        $psrResponse = new GuzzleResponse(
+            StatusCode::HTTP_CREATED,
+            ['Content-Type' => 'application/json', 'X-Custom' => 'test-value'],
+            '{"key":"value"}',
+        );
+
+        $response = new Response($psrResponse);
+
+        Assert::assertSame(StatusCode::HTTP_CREATED, $response->getStatusCode());
+        Assert::assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        Assert::assertSame('test-value', $response->getHeaderLine('X-Custom'));
+        Assert::assertSame('{"key":"value"}', (string)$response->getBody());
+    }
+
+
+    public function testGetInnerResponseReturnsSelf(): void
+    {
+        $response = new Response();
+
+        Assert::assertSame($response, $response->getInnerResponse());
+    }
+
+
+    public function testConstructorWithPsrResponsePreservesBodyForParsing(): void
+    {
+        $parsedBody = ['foo' => 'bar'];
+        $psrResponse = new GuzzleResponse(
+            StatusCode::HTTP_OK,
+            ['Content-Type' => 'application/json'],
+            '{"foo":"bar"}',
+        );
+
+        $response = new Response($psrResponse);
 
         Assert::assertSame($parsedBody, $response->getParsedBodyAsArray());
     }


### PR DESCRIPTION
Description: Add backward-compatible dual constructor and getInnerResponse() to Response for gradual Slim 4 migration
Possible impact: Response construction, PSR-7 interop

---
## Summary
- Add dual constructor to `Response` that accepts either legacy Slim 3 args `(int $status, ?HeadersInterface $headers, ?StreamInterface $body)` or a `PsrResponseInterface` instance
- Add `getInnerResponse(): PsrResponseInterface` to `ResponseInterface` and `Response` — currently returns `$this` (since Response IS PSR-7 via Slim 3 inheritance), will return the wrapped response after Slim 4 migration
- This is a **non-breaking 5.x change** — all existing constructor calls continue to work unchanged

## Why
This is a middle-step preparation for the Slim 3 → Slim 4 upgrade (PR #21011 in platform-backend). By enabling `new Response($psrResponse)` construction now, platform-backend can gradually migrate all ~25 Response constructor call sites to the new pattern in a separate PR before the actual Slim 4 switch. This makes the final upgrade PR significantly smaller and less risky.

## Migration path
1. **This PR** → release as v5.12 (non-breaking)
2. **platform-backend prep PR** → bump to v5.12, migrate `new Response(statusCode)` → `new Response($psrResponse)` across ~25 files
3. **Slim 4 upgrade PR** → much smaller, focused on the actual framework switch

## Test plan
- [x] PHPStan clean
- [x] ECS clean
- [x] All existing tests pass
- [x] New tests cover legacy constructor (defaults + custom status)
- [x] New tests cover PSR-7 wrapping constructor (status, headers, body preserved)
- [x] New test covers `getInnerResponse()` returns self
- [x] New test covers body parsing after PSR-7 wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)