### PR TITLE
DE-154553: Change interface return types to PSR-7 ResponseInterface

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\Slim;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Throwable;
 
 interface ErrorHandler
@@ -12,5 +13,5 @@ interface ErrorHandler
         RequestInterface $request,
         ResponseInterface $response,
         ?Throwable $exception = null
-    ): ResponseInterface;
+    ): PsrResponseInterface;
 }

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -4,8 +4,9 @@ namespace BrandEmbassy\Slim\Middleware;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 
 interface Middleware
 {
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface;
+    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next): PsrResponseInterface;
 }

--- a/src/Middleware/MiddlewareFactory.php
+++ b/src/Middleware/MiddlewareFactory.php
@@ -6,6 +6,7 @@ use BrandEmbassy\Slim\DI\ServiceProvider;
 use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use Nette\DI\Container;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use function array_map;
 use function assert;
 use function is_callable;
@@ -35,7 +36,7 @@ class MiddlewareFactory
         ) use (
             $middlewareIdentifier,
             $container
-        ): ResponseInterface {
+        ): PsrResponseInterface {
             $middleware = ServiceProvider::getService($container, $middlewareIdentifier);
             assert(is_callable($middleware));
 

--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -4,8 +4,9 @@ namespace BrandEmbassy\Slim\Route;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 
 interface Route
 {
-    public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface;
+    public function __invoke(RequestInterface $request, ResponseInterface $response): PsrResponseInterface;
 }

--- a/src/Route/RouteDefinitionFactory.php
+++ b/src/Route/RouteDefinitionFactory.php
@@ -8,6 +8,7 @@ use BrandEmbassy\Slim\Request\RequestInterface;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use LogicException;
 use Nette\DI\Container;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 
 /**
  * @final
@@ -38,7 +39,7 @@ class RouteDefinitionFactory
             ResponseInterface $response
         ) use (
             $routeDefinitionData
-        ): ResponseInterface {
+        ): PsrResponseInterface {
             $route = $this->getRoute($routeDefinitionData[RouteDefinition::SERVICE]);
 
             return $route($request, $response);


### PR DESCRIPTION
Description: Change return types in Middleware, Route, and ErrorHandler interfaces from BrandEmbassy ResponseInterface to PSR-7 ResponseInterface
Possible impact: All middleware, route, and error handler implementations across consuming projects

---

## Summary

- Change return types in `Middleware::__invoke()`, `Route::__invoke()`, and `ErrorHandler::__invoke()` from `BrandEmbassy\Slim\Response\ResponseInterface` to `Psr\Http\Message\ResponseInterface`
- Update internal wrappers in `MiddlewareFactory` and `RouteDefinitionFactory` to match
- Parameter types remain unchanged (`BrandEmbassy\Slim\Response\ResponseInterface`) for full backward compatibility

## Why

This is preparation for DE-154553 (Slim 3 → Slim 4 migration). By widening return types in the parent interfaces, we enable platform-backend to incrementally migrate its 800+ middleware/route implementations to use PSR-7 `ResponseInterface` directly.

**PHP type system guarantees backward compatibility:**
- **Covariance (return types)**: Existing implementations that return `BrandEmbassy\Slim\Response\ResponseInterface` remain valid — they return a subtype of the newly declared `Psr\Http\Message\ResponseInterface`
- **Contravariance (parameters)**: After this change, implementations can optionally widen their `$response` parameter to accept `Psr\Http\Message\ResponseInterface` — a wider type than the parent's declared parameter

## Verification

- [x] PHPStan: 0 errors
- [x] ECS: No code style issues
- [x] Rector: No suggestions
- [x] PHPUnit: All test implementations compile without fatal errors (pre-existing `apcu_enabled()` errors are unrelated infrastructure issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)