### PR TITLE
DE-154553: Fix array_merge_recursive → array_merge for middleware arrays

### DIFF
--- a/src/Middleware/MiddlewareGroups.php
+++ b/src/Middleware/MiddlewareGroups.php
@@ -3,7 +3,7 @@
 namespace BrandEmbassy\Slim\Middleware;
 
 use function array_map;
-use function array_merge_recursive;
+use function array_merge;
 
 /**
  * @final
@@ -53,6 +53,6 @@ class MiddlewareGroups
             $groupNames,
         );
 
-        return array_merge_recursive(...$groupsToMerge);
+        return array_merge(...$groupsToMerge);
     }
 }

--- a/src/Route/RouteRegister.php
+++ b/src/Route/RouteRegister.php
@@ -7,7 +7,7 @@ use BrandEmbassy\Slim\Middleware\BeforeRouteMiddlewares;
 use BrandEmbassy\Slim\Middleware\MiddlewareGroups;
 use Slim\Interfaces\RouterInterface;
 use function array_keys;
-use function array_merge_recursive;
+use function array_merge;
 use function levenshtein;
 
 /**
@@ -102,7 +102,7 @@ class RouteRegister
             $routeDefinition->getMiddlewareGroups(),
         );
 
-        return array_merge_recursive(
+        return array_merge(
             $this->afterRouteMiddlewares->getMiddlewares(),
             $routeDefinition->getMiddlewares(),
             $middlewaresFromGroups,


### PR DESCRIPTION
Description: Fix array_merge_recursive to array_merge for middleware arrays
Possible impact: Middleware registration, route middleware ordering

---
## Summary
- Changed `array_merge_recursive` to `array_merge` in `RouteRegister::getAllMiddlewares()` and `MiddlewareGroups::getMiddlewaresForMultipleGroups()`
- `array_merge_recursive` incorrectly merges same-key entries into nested arrays instead of appending them
- `array_merge` is the correct function for flat middleware lists
- This is a preparatory bugfix for the Slim 4 migration (part of DE-154553)

## Files Changed (2)
- `src/Route/RouteRegister.php` — `array_merge_recursive` → `array_merge`
- `src/Middleware/MiddlewareGroups.php` — `array_merge_recursive` → `array_merge`

## Risk Assessment
Low risk. Middleware arrays use numeric keys, so behavior is identical in practice. The semantic correctness matters if anyone ever uses string keys.

## Test Plan
- [x] Change is backward-compatible on Slim 3
- [ ] CI passes: PHPUnit + PHPStan + ECS + Rector on PHP 8.2/8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)