### PR TITLE
DE-154553: Add JsonResponse::from() static helper

### DIFF
--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\Slim\Response;
+
+use JsonException;
+use LogicException;
+use Psr\Http\Message\ResponseInterface;
+use Slim\Http\Body;
+use stdClass;
+use function fopen;
+use function json_encode;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @final
+ */
+class JsonResponse
+{
+    /**
+     * @param T $response
+     * @param mixed[]|stdClass $data
+     *
+     * @return T
+     *
+     * @throws JsonException
+     *
+     * @template T of ResponseInterface
+     */
+    public static function from(
+        ResponseInterface $response,
+        array|stdClass $data,
+        ?int $status = null,
+        int $encodingOptions = 0,
+    ): ResponseInterface {
+        $json = json_encode($data, $encodingOptions | JSON_THROW_ON_ERROR);
+
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
+            throw new LogicException('Failed to open php://temp stream');
+        }
+
+        $body = new Body($stream);
+        $body->write($json);
+        $body->rewind();
+
+        $response = $response
+            ->withBody($body)
+            ->withHeader('Content-Type', 'application/json;charset=utf-8');
+
+        if ($status !== null) {
+            return $response->withStatus($status);
+        }
+
+        return $response;
+    }
+}

--- a/tests/Response/JsonResponseTest.php
+++ b/tests/Response/JsonResponseTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyTest\Slim\Response;
+
+use BrandEmbassy\Slim\Response\JsonResponse;
+use BrandEmbassy\Slim\Response\Response;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use function json_decode;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @final
+ */
+class JsonResponseTest extends TestCase
+{
+    public function testFromWithArray(): void
+    {
+        $data = [
+            'foo' => 'bar',
+            'baz' => 42,
+        ];
+        $response = JsonResponse::from(new Response(), $data);
+
+        Assert::assertSame('application/json;charset=utf-8', $response->getHeaderLine('Content-Type'));
+        Assert::assertSame(200, $response->getStatusCode());
+
+        $body = (string)$response->getBody();
+        Assert::assertSame($data, json_decode($body, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+
+    public function testFromWithStdClass(): void
+    {
+        $data = new stdClass();
+        $data->key = 'value';
+
+        $response = JsonResponse::from(new Response(), $data);
+
+        $body = (string)$response->getBody();
+        Assert::assertSame('{"key":"value"}', $body);
+    }
+
+
+    public function testFromWithCustomStatus(): void
+    {
+        $response = JsonResponse::from(new Response(), ['created' => true], 201);
+
+        Assert::assertSame(201, $response->getStatusCode());
+    }
+
+
+    public function testFromWithEncodingOptions(): void
+    {
+        $data = ['foo' => 'bar'];
+        $response = JsonResponse::from(new Response(), $data, null, JSON_PRETTY_PRINT);
+
+        $expectedJson = <<<'JSON'
+{
+    "foo": "bar"
+}
+JSON;
+        Assert::assertSame($expectedJson, (string)$response->getBody());
+    }
+}


### PR DESCRIPTION
Description: Add JsonResponse::from() as a framework-agnostic alternative to withJson()
Possible impact: Response handling, JSON serialization

---
## Summary
- Introduces `JsonResponse::from()` static method that works with any PSR-7 `ResponseInterface`
- Provides a clean migration path away from Slim-specific `$response->withJson()`
- Uses `Slim\Http\Body` for stream creation (Slim 3 compatible)
- Includes comprehensive test coverage
- This is a preparatory step for the Slim 4 migration (part of DE-154553)

## New Files
- `src/Response/JsonResponse.php` — Static `from()` method accepting response, data, optional status, and encoding options
- `tests/Response/JsonResponseTest.php` — Tests for array data, stdClass, custom status, and encoding options

## Usage
```php
// Before (Slim-specific):
$response->withJson($data, 200);

// After (framework-agnostic):
JsonResponse::from($response, $data, 200);
```

## Test Plan
- [x] PHPStan level 8 passes
- [x] ECS coding standards pass
- [x] 4 unit tests covering all use cases
- [ ] CI passes: PHPUnit + PHPStan + ECS + Rector on PHP 8.2/8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)