### PR TITLE
DE-154553: Deprecate interface methods planned for removal in v6

### DIFF
--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -27,18 +27,24 @@ interface RequestInterface extends ServerRequestInterface
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getParsedBody() and cast to array instead.
+     *
      * @return mixed[]
      */
     public function getParsedBodyAsArray(): array;
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getParsedBody() with dot-notation access instead.
+     *
      * @return mixed
      */
     public function getField(string $name);
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getParsedBody() with dot-notation access instead.
+     *
      * @param mixed $default
      *
      * @return mixed
@@ -46,16 +52,23 @@ interface RequestInterface extends ServerRequestInterface
     public function findField(string $fieldName, $default = null);
 
 
+    /**
+     * @deprecated Will be removed in v6. Use PSR-7 getParsedBody() with dot-notation access instead.
+     */
     public function hasField(string $fieldName): bool;
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getQueryParams() instead.
+     *
      * @return string|string[]|null
      */
     public function findQueryParam(string $key, ?string $default = null);
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getQueryParams() instead.
+     *
      * @return string|string[]
      *
      * @throws QueryParamMissingException
@@ -63,19 +76,29 @@ interface RequestInterface extends ServerRequestInterface
     public function getQueryParamStrict(string $key);
 
 
+    /**
+     * @deprecated Will be removed in v6. Use PSR-7 getQueryParams() instead.
+     */
     public function findQueryParamAsString(string $key, ?string $default = null): ?string;
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getQueryParams() instead.
+     *
      * @throws QueryParamMissingException
      */
     public function getQueryParamAsString(string $key): string;
 
 
+    /**
+     * @deprecated Will be removed in v6. Use PSR-7 getAttributes() with array_key_exists() instead.
+     */
     public function hasAttribute(string $name): bool;
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getAttribute() instead.
+     *
      * @param mixed $default
      *
      * @return mixed
@@ -84,17 +107,28 @@ interface RequestInterface extends ServerRequestInterface
 
 
     /**
+     * @deprecated Will be removed in v6. Use PSR-7 getAttribute() instead.
+     *
      * @return mixed
      */
     public function getAttributeStrict(string $name);
 
 
+    /**
+     * @deprecated Will be removed in v6. Use PSR-7 getQueryParams() with array_key_exists() instead.
+     */
     public function hasQueryParam(string $key): bool;
 
 
+    /**
+     * @deprecated Will be removed in v6. Parse datetime from getQueryParams() directly.
+     */
     public function getDateTimeQueryParam(string $key): DateTimeImmutable;
 
 
+    /**
+     * @deprecated Will be removed in v6. Check Accept header via getHeaderLine('Accept') instead.
+     */
     public function isHtml(): bool;
 
 

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -10,6 +10,8 @@ use stdClass;
 interface ResponseInterface extends PsrResponseInterface
 {
     /**
+     * @deprecated Use JsonResponse::from() instead
+     *
      * @param mixed[]|stdClass $data
      *
      * @return static
@@ -18,6 +20,8 @@ interface ResponseInterface extends PsrResponseInterface
 
 
     /**
+     * @deprecated Use PSR-7 $response->withHeader('Location', $url)->withStatus($statusCode) instead
+     *
      * @param string|UriInterface $url
      *
      * @return static
@@ -26,6 +30,8 @@ interface ResponseInterface extends PsrResponseInterface
 
 
     /**
+     * @deprecated Will be removed in v6. Decode the response body directly.
+     *
      * @return mixed[]
      */
     public function getParsedBodyAsArray(): array;


### PR DESCRIPTION
Description: Add @deprecated annotations to interface methods that will be removed in the Slim 4 migration
Possible impact: IDE warnings for consumers using deprecated methods (zero runtime impact)

---
## Summary
Adds `@deprecated` PHPDoc annotations to methods that will be removed in v6, giving consumers IDE warnings and time to migrate.

**Depends on**: #100 (Prep PR C — JsonResponse helper, which is referenced in deprecation messages)

## ResponseInterface — 3 methods deprecated
- `withJson()` — use `JsonResponse::from()` instead
- `withRedirect()` — use PSR-7 `$response->withHeader('Location', $url)->withStatus($statusCode)` instead
- `getParsedBodyAsArray()` — decode the response body directly

## RequestInterface — 12 methods deprecated (2 were already deprecated)
- **Field helpers**: `getField()`, `findField()`, `hasField()` — use PSR-7 `getParsedBody()` instead
- **Query param helpers**: `findQueryParam()`, `getQueryParamStrict()`, `findQueryParamAsString()`, `getQueryParamAsString()`, `hasQueryParam()` — use PSR-7 `getQueryParams()` instead
- **Attribute helpers**: `hasAttribute()`, `findAttribute()`, `getAttributeStrict()` — use PSR-7 `getAttribute()`/`getAttributes()` instead
- `getDateTimeQueryParam()` — parse datetime from `getQueryParams()` directly
- `isHtml()` — check Accept header via `getHeaderLine('Accept')` instead

## Test Plan
- [x] PHPStan passes — annotations are documentation only
- [x] Zero runtime impact — only PHPDoc changes
- [ ] CI passes: PHPUnit + PHPStan + ECS + Rector on PHP 8.2/8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)