### PR TITLE
DE-154553: Hollow out ResponseInterface — remove deprecated methods

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -2,70 +2,14 @@
 
 namespace BrandEmbassy\Slim\Response;
 
-use JsonException;
-use Nette\Utils\Json;
-use Psr\Http\Message\UriInterface;
-use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Response as SlimResponse;
-use stdClass;
-use function assert;
-use function is_array;
-use function json_encode;
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @final
  *
- * Extends Slim 4's PSR-7 Response with convenience methods.
+ * Extends Slim 4's PSR-7 Response.
  * All PSR-7 methods are inherited from the parent.
  */
 class Response extends SlimResponse implements ResponseInterface
 {
-    /**
-     * @return mixed[]
-     *
-     * @throws JsonException
-     */
-    public function getParsedBodyAsArray(): array
-    {
-        $parsedBody = Json::decode((string)$this->getBody(), Json::FORCE_ARRAY);
-        assert(is_array($parsedBody));
-
-        return $parsedBody;
-    }
-
-
-    /**
-     * @param mixed[]|stdClass $data
-     *
-     * @throws JsonException
-     */
-    public function withJson($data, ?int $status = null, int $encodingOptions = 0): static
-    {
-        $json = json_encode($data, $encodingOptions | JSON_THROW_ON_ERROR);
-
-        $streamFactory = new StreamFactory();
-        $body = $streamFactory->createStream($json);
-
-        $response = $this
-            ->withBody($body)
-            ->withHeader('Content-Type', 'application/json;charset=utf-8');
-
-        if ($status !== null) {
-            return $response->withStatus($status);
-        }
-
-        return $response;
-    }
-
-
-    /**
-     * @param string|UriInterface $url
-     */
-    public function withRedirect($url, int $statusCode = 302): static
-    {
-        return $this
-            ->withHeader('Location', (string)$url)
-            ->withStatus($statusCode);
-    }
 }

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -3,35 +3,7 @@
 namespace BrandEmbassy\Slim\Response;
 
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
-use Psr\Http\Message\UriInterface;
-use stdClass;
 
 interface ResponseInterface extends PsrResponseInterface
 {
-    /**
-     * @deprecated Use JsonResponse::from() instead
-     *
-     * @param mixed[]|stdClass $data
-     *
-     * @return static
-     */
-    public function withJson($data, ?int $status = null, int $encodingOptions = 0);
-
-
-    /**
-     * @deprecated Use PSR-7 $response->withHeader('Location', $url)->withStatus($statusCode) instead
-     *
-     * @param string|UriInterface $url
-     *
-     * @return static
-     */
-    public function withRedirect($url, int $statusCode = 302);
-
-
-    /**
-     * @deprecated Will be removed in v6. Decode the response body directly.
-     *
-     * @return mixed[]
-     */
-    public function getParsedBodyAsArray(): array;
 }


### PR DESCRIPTION
Description: Remove withJson, withRedirect, getParsedBodyAsArray from ResponseInterface and Response
Possible impact: Response handling — consumers must use JsonResponse::from() and PSR-7 methods

---
## Summary
**Part 2 of the v6 migration series (targets `v6-dev` branch)**

Removes the three deprecated methods from `ResponseInterface` and `Response`:
- `withJson()` → use `JsonResponse::from()` instead
- `withRedirect()` → use PSR-7 `$response->withHeader('Location', $url)->withStatus($statusCode)`
- `getParsedBodyAsArray()` → decode the response body directly

**Depends on**: #102 (PR 1 — Core Slim 4 migration)

## Files Changed (2)
- `src/Response/ResponseInterface.php` — becomes empty interface extending `PsrResponseInterface`
- `src/Response/Response.php` — becomes bare class extending `Slim\Psr7\Response`

## Breaking Change
Consumers using `$response->withJson()`, `$response->withRedirect()`, or `$response->getParsedBodyAsArray()` must migrate to the alternatives listed above.

## Verification
- [x] PHPStan level 8 — 0 errors
- [x] PHPUnit — 29/29 tests pass
- [ ] CI passes on PHP 8.2/8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)