### PR TITLE
DE-154553: Migrate test samples from withJson() to JsonResponse::from()

### DIFF
--- a/tests/Sample/ApiErrorHandler.php
+++ b/tests/Sample/ApiErrorHandler.php
@@ -4,6 +4,7 @@ namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\ErrorHandler;
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use Throwable;
 
@@ -21,6 +22,6 @@ class ApiErrorHandler implements ErrorHandler
             ? $exception->getMessage()
             : 'Unknown error.';
 
-        return $response->withJson(['error' => $error], 500);
+        return JsonResponse::from($response, ['error' => $error], 500);
     }
 }

--- a/tests/Sample/CreateChannelRoute.php
+++ b/tests/Sample/CreateChannelRoute.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use BrandEmbassy\Slim\Route\Route;
 
@@ -11,9 +12,8 @@ use BrandEmbassy\Slim\Route\Route;
  */
 class CreateChannelRoute implements Route
 {
-
     public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        return $response->withJson(['status' => 'created'], 201);
+        return JsonResponse::from($response, ['status' => 'created'], 201);
     }
 }

--- a/tests/Sample/GoldenKeyAuthMiddleware.php
+++ b/tests/Sample/GoldenKeyAuthMiddleware.php
@@ -4,6 +4,7 @@ namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\Middleware\Middleware;
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 
 /**
@@ -19,7 +20,7 @@ class GoldenKeyAuthMiddleware implements Middleware
         $token = $request->getHeaderLine('X-Api-Key');
 
         if ($token !== self::ACCESS_TOKEN) {
-            return $response->withJson(['error' => 'YOU SHALL NOT PASS!'], 401);
+            return JsonResponse::from($response, ['error' => 'YOU SHALL NOT PASS!'], 401);
         }
 
         return $next($request, $response);

--- a/tests/Sample/HelloWorldRoute.php
+++ b/tests/Sample/HelloWorldRoute.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use BrandEmbassy\Slim\Route\Route;
 
@@ -13,6 +14,6 @@ class HelloWorldRoute implements Route
 {
     public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        return $response->withJson(['Hello World']);
+        return JsonResponse::from($response, ['Hello World']);
     }
 }

--- a/tests/Sample/ListChannelsRoute.php
+++ b/tests/Sample/ListChannelsRoute.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use BrandEmbassy\Slim\Route\Route;
 
@@ -13,7 +14,8 @@ class ListChannelsRoute implements Route
 {
     public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        return $response->withJson(
+        return JsonResponse::from(
+            $response,
             [
                 [
                     'id' => 1,
@@ -24,7 +26,7 @@ class ListChannelsRoute implements Route
                     'name' => 'Second channel',
                 ],
             ],
-            200
+            200,
         );
     }
 }

--- a/tests/Sample/NotAllowedHandler.php
+++ b/tests/Sample/NotAllowedHandler.php
@@ -3,6 +3,7 @@
 namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 
 /**
@@ -14,6 +15,6 @@ class NotAllowedHandler
 {
     public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        return $response->withJson(['error' => 'Sample NotAllowedHandler here!'], 405);
+        return JsonResponse::from($response, ['error' => 'Sample NotAllowedHandler here!'], 405);
     }
 }

--- a/tests/Sample/NotFoundHandler.php
+++ b/tests/Sample/NotFoundHandler.php
@@ -4,6 +4,7 @@ namespace BrandEmbassyTest\Slim\Sample;
 
 use BrandEmbassy\Slim\ErrorHandler;
 use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\JsonResponse;
 use BrandEmbassy\Slim\Response\ResponseInterface;
 use Throwable;
 
@@ -17,6 +18,6 @@ class NotFoundHandler implements ErrorHandler
         ResponseInterface $response,
         ?Throwable $exception = null
     ): ResponseInterface {
-        return $response->withJson(['error' => 'Sample NotFoundHandler here!'], 404);
+        return JsonResponse::from($response, ['error' => 'Sample NotFoundHandler here!'], 404);
     }
 }


### PR DESCRIPTION
Description: Replace withJson() calls in test samples with JsonResponse::from()
Possible impact: Test samples only — zero production impact

---
## Summary
Migrates all 7 test sample files from `$response->withJson()` to `JsonResponse::from()`, proving the migration path works on Slim 3 before the v4 migration.

**Depends on**: #100 (Prep PR C — JsonResponse helper)

## Files Changed (7)
- `tests/Sample/ApiErrorHandler.php`
- `tests/Sample/CreateChannelRoute.php`
- `tests/Sample/NotFoundHandler.php`
- `tests/Sample/ListChannelsRoute.php`
- `tests/Sample/HelloWorldRoute.php`
- `tests/Sample/NotAllowedHandler.php`
- `tests/Sample/GoldenKeyAuthMiddleware.php`

## Pattern
```php
// Before
return $response->withJson(['error' => $error], 500);

// After
return JsonResponse::from($response, ['error' => $error], 500);
```

## Test Plan
- [x] PHPStan level 8 — 0 errors
- [x] ECS coding standards — 0 errors
- [ ] CI passes: PHPUnit + PHPStan + ECS + Rector on PHP 8.2/8.3/8.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)