### PR TITLE
DE-160171 Update PHP constraint for PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": "~8.2 || ~8.4",
         "ext-apcu": "*",
         "adbario/php-dot-notation": "^2.2 || ^3.0",
         "nette/di": "^3.0",


### PR DESCRIPTION
Description: Update PHP version constraint to ~8.2 || ~8.4 for PHP 8.4 compatibility
Possible impact: PHP version constraint only, no code changes

---
## Summary
- Update PHP version constraint to `~8.2 || ~8.4`
- Full codebase scan found zero PHP 8.4 breaking changes
- No code modifications needed

## Test Plan
- [x] Scanned for implicit nullable params (BC-001) - none found
- [x] Scanned for get_class() without args (BC-002) - none found
- [x] Scanned for other PHP 8.4 deprecations - none found
- [ ] CI passes on PHP 8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)