### PR TITLE
ci: add PHP Upgrade Rector Proposals workflow

### DIFF
--- a/.github/workflows/php-upgrade-rector-proposals.yml
+++ b/.github/workflows/php-upgrade-rector-proposals.yml
@@ -1,0 +1,18 @@
+name: PHP Upgrade Rector Proposals
+
+on:
+  workflow_dispatch:
+    inputs:
+      PHP_TARGET_VERSION:
+        required: true
+        type: string
+        description: 'Target PHP version (e.g. 8.4)'
+        default: '8.4'
+
+jobs:
+  rector-php-upgrade:
+    uses: BrandEmbassy/github-actions/.github/workflows/php-upgrade-rector-proposals.yml@master
+    with:
+      PHP_TARGET_VERSION: ${{ inputs.PHP_TARGET_VERSION }}
+    secrets:
+      COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}

--- a/.github/workflows/php-upgrade-rector-proposals.yml
+++ b/.github/workflows/php-upgrade-rector-proposals.yml
@@ -14,5 +14,6 @@ jobs:
     uses: BrandEmbassy/github-actions/.github/workflows/php-upgrade-rector-proposals.yml@master
     with:
       PHP_TARGET_VERSION: ${{ inputs.PHP_TARGET_VERSION }}
+      RECTOR_PATHS: 'src tests'
     secrets:
       COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}


### PR DESCRIPTION
Description: Add PHP Upgrade Rector Proposals reusable workflow
Possible impact: CI/CD workflows

---
## Summary
- Adds the PHP Upgrade Rector Proposals workflow (dispatch-triggered)
- Uses the reusable workflow from BrandEmbassy/github-actions
- Allows running Rector PHP upgrade proposals against this repo via GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)