### PR TITLE
DE-154553: Fix lazy route service resolution to match Slim 3 behavior

### DIFF
--- a/src/Route/LazyRoute.php
+++ b/src/Route/LazyRoute.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\Slim\Route;
+
+use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\ResponseInterface;
+use Closure;
+use function assert;
+
+/**
+ * @final
+ *
+ * Lazily resolves a Route from the container on first invocation.
+ * This preserves Slim 3 behavior where route services were only
+ * instantiated when the matched route was actually invoked.
+ */
+class LazyRoute implements Route
+{
+    /**
+     * @var (Closure(): Route)|null
+     */
+    private ?Closure $factory;
+
+    private ?Route $resolvedRoute = null;
+
+
+    /**
+     * @param Closure(): Route $factory
+     */
+    public function __construct(Closure $factory)
+    {
+        $this->factory = $factory;
+    }
+
+
+    public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        if ($this->resolvedRoute === null) {
+            assert($this->factory !== null);
+            $this->resolvedRoute = ($this->factory)();
+            $this->factory = null;
+        }
+
+        return ($this->resolvedRoute)($request, $response);
+    }
+}

--- a/src/Route/RouteDefinitionFactory.php
+++ b/src/Route/RouteDefinitionFactory.php
@@ -31,8 +31,9 @@ class RouteDefinitionFactory
      */
     public function create(string $method, array $routeDefinitionData): RouteDefinition
     {
-        $route = $this->getRoute($routeDefinitionData[RouteDefinition::SERVICE]);
-        $routeHandler = new LegacyRouteAdapter($route);
+        $serviceIdentifier = $routeDefinitionData[RouteDefinition::SERVICE];
+        $lazyRoute = new LazyRoute(fn(): Route => $this->getRoute($serviceIdentifier));
+        $routeHandler = new LegacyRouteAdapter($lazyRoute);
 
         $middlewares = $this->middlewareFactory->createFromIdentifiers(
             $routeDefinitionData[RouteDefinition::MIDDLEWARES],


### PR DESCRIPTION
Description: Fix lazy route service resolution to match Slim 3 behavior
Possible impact: Route handler instantiation timing, integration test UUID sequences

---

## Summary
- In Slim 3, route services were resolved lazily via a closure — only when the matched route was invoked
- The Slim 4 migration changed this to eager resolution during `SlimApplicationFactory::create()`, causing ALL route handler services to be instantiated from the container at once
- This broke integration tests in platform-backend that rely on deterministic UUID sequences (`TestIdGenerator`), because eager resolution triggered constructor chains that consumed extra UUIDs before the test's expected code path ran (shifting all UUIDs by 1 position)
- Introduces `LazyRoute` which wraps a closure that resolves the `Route` from the container on first invocation, restoring the original lazy behavior

## Changes
- **New**: `LazyRoute.php` — Lazy proxy implementing `Route` that defers container resolution until first invocation
- **Modified**: `RouteDefinitionFactory.php` — Uses `LazyRoute` instead of eager `getRoute()` call

## Test Plan
- [x] All 19 slim-nette-extension unit tests pass
- [x] PHPStan passes (0 errors)
- [x] ECS passes (0 errors)
- [ ] platform-backend integration tests should pass with this fix (UUID sequence restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)