### PR TITLE
DE-154553: Fix lazy middleware resolution to match Slim 3 behavior

### DIFF
--- a/src/Middleware/MiddlewareFactory.php
+++ b/src/Middleware/MiddlewareFactory.php
@@ -7,9 +7,10 @@ use Nette\DI\Container;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use RuntimeException;
 use function array_map;
-use function assert;
 use function is_callable;
+use function sprintf;
 
 /**
  * @final
@@ -39,7 +40,13 @@ class MiddlewareFactory
                 $container
             ): ResponseInterface {
                 $middleware = ServiceProvider::getService($container, $middlewareIdentifier);
-                assert(is_callable($middleware));
+
+                if (!is_callable($middleware)) {
+                    throw new RuntimeException(sprintf(
+                        'Resolved middleware "%s" is not callable.',
+                        $middlewareIdentifier,
+                    ));
+                }
 
                 return $middleware($request, $response, $next);
             },

--- a/src/Middleware/MiddlewareFactory.php
+++ b/src/Middleware/MiddlewareFactory.php
@@ -4,6 +4,8 @@ namespace BrandEmbassy\Slim\Middleware;
 
 use BrandEmbassy\Slim\DI\ServiceProvider;
 use Nette\DI\Container;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use function array_map;
 use function assert;
@@ -25,10 +27,23 @@ class MiddlewareFactory
 
     public function createFromIdentifier(string $middlewareIdentifier): MiddlewareInterface
     {
-        $middleware = ServiceProvider::getService($this->container, $middlewareIdentifier);
-        assert(is_callable($middleware));
+        $container = $this->container;
 
-        return new DoublePassMiddlewareAdapter($middleware);
+        return new DoublePassMiddlewareAdapter(
+            static function (
+                ServerRequestInterface $request,
+                ResponseInterface $response,
+                callable $next,
+            ) use (
+                $middlewareIdentifier,
+                $container
+            ): ResponseInterface {
+                $middleware = ServiceProvider::getService($container, $middlewareIdentifier);
+                assert(is_callable($middleware));
+
+                return $middleware($request, $response, $next);
+            },
+        );
     }
 
 

--- a/tests/Middleware/MiddlewareFactoryTest.php
+++ b/tests/Middleware/MiddlewareFactoryTest.php
@@ -32,13 +32,7 @@ class MiddlewareFactoryTest extends TestCase
             ->willReturnCallback(static function () use ($counter): callable {
                 $counter->value++;
 
-                return static function (
-                    Request $request,
-                    Response $response,
-                    callable $next,
-                ): ResponseInterface {
-                    return $response;
-                };
+                return static fn(Request $request, Response $response, callable $next): ResponseInterface => $response;
             });
 
         $factory = new MiddlewareFactory($container);
@@ -67,13 +61,7 @@ class MiddlewareFactoryTest extends TestCase
             ->willReturnCallback(static function () use ($counter): callable {
                 $counter->value++;
 
-                return static function (
-                    Request $request,
-                    Response $response,
-                    callable $next,
-                ): ResponseInterface {
-                    return $response;
-                };
+                return static fn(Request $request, Response $response, callable $next): ResponseInterface => $response;
             });
 
         $factory = new MiddlewareFactory($container);

--- a/tests/Middleware/MiddlewareFactoryTest.php
+++ b/tests/Middleware/MiddlewareFactoryTest.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyTest\Slim\Middleware;
+
+use BrandEmbassy\Slim\Middleware\MiddlewareFactory;
+use BrandEmbassy\Slim\Request\Request;
+use BrandEmbassy\Slim\Response\Response;
+use Nette\DI\Container;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use stdClass;
+
+/**
+ * @final
+ */
+class MiddlewareFactoryTest extends TestCase
+{
+    public function testMiddlewareIsResolvedLazilyNotDuringCreation(): void
+    {
+        $resolveCount = 0;
+
+        $container = $this->createMock(Container::class);
+        $container->method('getByName')
+            ->with('lazyMiddleware')
+            ->willReturnCallback(static function () use (&$resolveCount): callable {
+                $resolveCount++;
+
+                return static function (
+                    Request $request,
+                    Response $response,
+                    callable $next,
+                ): ResponseInterface {
+                    return $response;
+                };
+            });
+
+        $factory = new MiddlewareFactory($container);
+
+        $middleware = $factory->createFromIdentifier('lazyMiddleware');
+
+        Assert::assertSame(0, $resolveCount, 'Service must NOT be resolved during createFromIdentifier()');
+
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/test');
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $middleware->process($request, $handler);
+
+        Assert::assertSame(1, $resolveCount, 'Service must be resolved when middleware processes a request');
+    }
+
+
+    public function testMiddlewareIsResolvedOnEachRequest(): void
+    {
+        $resolveCount = 0;
+
+        $container = $this->createMock(Container::class);
+        $container->method('getByName')
+            ->willReturnCallback(static function () use (&$resolveCount): callable {
+                $resolveCount++;
+
+                return static function (
+                    Request $request,
+                    Response $response,
+                    callable $next,
+                ): ResponseInterface {
+                    return $response;
+                };
+            });
+
+        $factory = new MiddlewareFactory($container);
+        $middleware = $factory->createFromIdentifier('someMiddleware');
+
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/test');
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $middleware->process($request, $handler);
+        $middleware->process($request, $handler);
+
+        Assert::assertSame(2, $resolveCount, 'Service must be resolved on each request');
+    }
+
+
+    public function testThrowsExceptionWhenResolvedServiceIsNotCallable(): void
+    {
+        $container = $this->createMock(Container::class);
+        $container->method('getByName')
+            ->willReturn(new stdClass());
+
+        $factory = new MiddlewareFactory($container);
+        $middleware = $factory->createFromIdentifier('notCallableMiddleware');
+
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/test');
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Resolved middleware "notCallableMiddleware" is not callable.');
+
+        $middleware->process($request, $handler);
+    }
+
+
+    public function testCreateFromIdentifiersReturnsCorrectCount(): void
+    {
+        $container = $this->createMock(Container::class);
+
+        $factory = new MiddlewareFactory($container);
+        $middlewares = $factory->createFromIdentifiers(['a', 'b', 'c']);
+
+        Assert::assertCount(3, $middlewares);
+    }
+}

--- a/tests/Middleware/MiddlewareFactoryTest.php
+++ b/tests/Middleware/MiddlewareFactoryTest.php
@@ -22,13 +22,15 @@ class MiddlewareFactoryTest extends TestCase
 {
     public function testMiddlewareIsResolvedLazilyNotDuringCreation(): void
     {
-        $resolveCount = 0;
+        $counter = new class {
+            public int $value = 0;
+        };
 
         $container = $this->createMock(Container::class);
         $container->method('getByName')
             ->with('lazyMiddleware')
-            ->willReturnCallback(static function () use (&$resolveCount): callable {
-                $resolveCount++;
+            ->willReturnCallback(static function () use ($counter): callable {
+                $counter->value++;
 
                 return static function (
                     Request $request,
@@ -43,25 +45,27 @@ class MiddlewareFactoryTest extends TestCase
 
         $middleware = $factory->createFromIdentifier('lazyMiddleware');
 
-        Assert::assertSame(0, $resolveCount, 'Service must NOT be resolved during createFromIdentifier()');
+        Assert::assertSame(0, $counter->value, 'Service must NOT be resolved during createFromIdentifier()');
 
         $request = (new ServerRequestFactory())->createServerRequest('GET', '/test');
         $handler = $this->createMock(RequestHandlerInterface::class);
 
         $middleware->process($request, $handler);
 
-        Assert::assertSame(1, $resolveCount, 'Service must be resolved when middleware processes a request');
+        Assert::assertSame(1, $counter->value, 'Service must be resolved when middleware processes a request');
     }
 
 
     public function testMiddlewareIsResolvedOnEachRequest(): void
     {
-        $resolveCount = 0;
+        $counter = new class {
+            public int $value = 0;
+        };
 
         $container = $this->createMock(Container::class);
         $container->method('getByName')
-            ->willReturnCallback(static function () use (&$resolveCount): callable {
-                $resolveCount++;
+            ->willReturnCallback(static function () use ($counter): callable {
+                $counter->value++;
 
                 return static function (
                     Request $request,
@@ -81,7 +85,7 @@ class MiddlewareFactoryTest extends TestCase
         $middleware->process($request, $handler);
         $middleware->process($request, $handler);
 
-        Assert::assertSame(2, $resolveCount, 'Service must be resolved on each request');
+        Assert::assertSame(2, $counter->value, 'Service must be resolved on each request');
     }
 
 


### PR DESCRIPTION
Description: Fix middleware services being eagerly resolved during route registration instead of lazily during request handling
Possible impact: Middleware initialization, DI container service resolution during bootstrap

---

## Problem

In Slim 3 (v5.x), `MiddlewareFactory::createFromIdentifier()` returned a closure that lazily resolved the middleware service from the DI container only when invoked during request handling.

The Slim 4 migration (v6.0) changed this to eager resolution — `ServiceProvider::getService()` is called immediately during route registration in `SlimApplicationFactory::create()`. This causes ALL middleware dependencies to be resolved during bootstrap, before any HTTP request is available.

This breaks services like `DefaultUseReadonlyReplicaResolver` which need the current request to determine database connection routing:

```
LogicException: Request must be set when this method is called. Entity Manager must be initialized only AFTER slim finds the appropriate route.
```

The previous fix (#113) made Route resolution lazy via `LazyRoute`, but middleware resolution remained eager.

## Fix

Wraps the service resolution in a closure inside `DoublePassMiddlewareAdapter`. The actual middleware service is only resolved from the container when its `process()` method is called during request handling — exactly matching Slim 3 behavior.

## Verification

- All 19 tests pass
- PHPStan level 8 clean
- ECS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)