### PR TITLE
DE-154553: Add body parsing middleware for Slim 4

### DIFF
--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -128,6 +128,9 @@ class SlimApplicationFactory
         $handlers = $this->resolveHandlers();
 
         // Slim 4 uses a LIFO middleware stack: middleware added later runs earlier on request.
+        // Body parsing replaces Slim 3's automatic JSON body parsing.
+        $slimApp->addBodyParsingMiddleware();
+
         // Routing middleware resolves the matched route before route handlers execute.
         $slimApp->addRoutingMiddleware();
 

--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -127,22 +127,36 @@ class SlimApplicationFactory
 
         $handlers = $this->resolveHandlers();
 
-        // Slim 4 uses a LIFO middleware stack: middleware added later runs earlier on request.
-        // Body parsing replaces Slim 3's automatic JSON body parsing.
-        $slimApp->addBodyParsingMiddleware();
+        $this->registerMiddlewares($slimApp, $handlers);
 
-        // Routing middleware resolves the matched route before route handlers execute.
+        return $slimApp;
+    }
+
+
+    /**
+     * Registers all middleware in the correct order for Slim 4's LIFO stack.
+     * Last added = first to execute on request (outermost).
+     *
+     * Execution order on request:
+     *   1. beforeRequestMiddlewares (CORS, trace ID, …)
+     *   2. Error handling
+     *   3. Routing (resolves matched route)
+     *   4. Body parsing (JSON, XML, form-urlencoded)
+     *   5. Route-level middlewares + handler
+     *
+     * @param array<string, callable> $handlers
+     */
+    private function registerMiddlewares(SlimApp $slimApp, array $handlers): void
+    {
+        $slimApp->addBodyParsingMiddleware();
         $slimApp->addRoutingMiddleware();
 
-        // Error middleware wraps everything — catches exceptions from routing and handlers.
         $errorMiddleware = $slimApp->addErrorMiddleware(true, true, true);
         $errorMiddleware->setDefaultErrorHandler(new ErrorHandlerBridge($handlers));
 
         foreach ($this->configuration[self::BEFORE_REQUEST_MIDDLEWARES] as $middlewareIdentifier) {
             $slimApp->add($this->middlewareFactory->createFromIdentifier($middlewareIdentifier));
         }
-
-        return $slimApp;
     }
 
 

--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -82,6 +82,18 @@ class SlimApplicationFactory
 
     public function create(): SlimApp
     {
+        $slimContainer = new SlimContainer($this->container);
+        $slimApp = new SlimApp(new ResponseFactory(), $slimContainer);
+
+        $this->registerRoutes($slimApp);
+        $this->registerMiddlewares($slimApp);
+
+        return $slimApp;
+    }
+
+
+    private function registerRoutes(SlimApp $slimApp): void
+    {
         $detectTyposInRouteConfiguration = (bool)$this->getSlimSettings(
             SlimSettings::DETECT_TYPOS_IN_ROUTE_CONFIGURATION,
             true,
@@ -104,11 +116,6 @@ class SlimApplicationFactory
             $useApcuCache = false;
         }
 
-        $slimContainer = new SlimContainer($this->container);
-        $psrResponseFactory = new ResponseFactory();
-
-        $slimApp = new SlimApp($psrResponseFactory, $slimContainer);
-
         $routesToRegister = $this->configuration[self::ROUTES];
         if ($registerOnlyNecessaryRoutes) {
             $requestUri = $_SERVER['REQUEST_URI'] ?? null;
@@ -124,12 +131,6 @@ class SlimApplicationFactory
         foreach ($routesToRegister as $apiNamespace => $routes) {
             $this->registerApi($slimApp, $apiNamespace, $routes, $detectTyposInRouteConfiguration);
         }
-
-        $handlers = $this->resolveHandlers();
-
-        $this->registerMiddlewares($slimApp, $handlers);
-
-        return $slimApp;
     }
 
 
@@ -143,14 +144,13 @@ class SlimApplicationFactory
      *   3. Routing (resolves matched route)
      *   4. Body parsing (JSON, XML, form-urlencoded)
      *   5. Route-level middlewares + handler
-     *
-     * @param array<string, callable> $handlers
      */
-    private function registerMiddlewares(SlimApp $slimApp, array $handlers): void
+    private function registerMiddlewares(SlimApp $slimApp): void
     {
         $slimApp->addBodyParsingMiddleware();
         $slimApp->addRoutingMiddleware();
 
+        $handlers = $this->resolveHandlers();
         $errorMiddleware = $slimApp->addErrorMiddleware(true, true, true);
         $errorMiddleware->setDefaultErrorHandler(new ErrorHandlerBridge($handlers));
 

--- a/tests/Sample/EchoParsedBodyRoute.php
+++ b/tests/Sample/EchoParsedBodyRoute.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassyTest\Slim\Sample;
+
+use BrandEmbassy\Slim\Request\RequestInterface;
+use BrandEmbassy\Slim\Response\ResponseInterface;
+use BrandEmbassy\Slim\Route\Route;
+use BrandEmbassyTest\Slim\Tools\ResponseCreatorTestTool;
+
+/**
+ * @final
+ */
+class EchoParsedBodyRoute implements Route
+{
+    public function __invoke(RequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $parsedBody = $request->getParsedBodyAsArray();
+
+        return ResponseCreatorTestTool::createJsonResponse($response, $parsedBody, 200);
+    }
+}

--- a/tests/SlimApplicationFactoryTest.php
+++ b/tests/SlimApplicationFactoryTest.php
@@ -10,8 +10,11 @@ use BrandEmbassyTest\Slim\Sample\GroupMiddleware;
 use BrandEmbassyTest\Slim\Sample\InvokeCounterMiddleware;
 use BrandEmbassyTest\Slim\Sample\OnlyApiGroupMiddleware;
 use BrandEmbassyTest\Slim\Tools\ResponseAssertions;
+use Nette\Utils\Json;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Factory\StreamFactory;
 use function count;
 
 /**
@@ -224,6 +227,22 @@ class SlimApplicationFactoryTest extends TestCase
         foreach ($headers as $name => $value) {
             $_SERVER[$name] = $value;
         }
+    }
+
+
+    public function testJsonBodyIsParsedForRouteHandlers(): void
+    {
+        $requestBody = ['status' => 'closed'];
+        $jsonBody = Json::encode($requestBody);
+
+        $request = (new ServerRequestFactory())
+            ->createServerRequest('PUT', '/tests/api/echo-body')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody((new StreamFactory())->createStream($jsonBody));
+
+        $response = SlimAppTester::runSlimApp(__DIR__ . '/config.neon', $request);
+
+        ResponseAssertions::assertJsonResponseEqualsArray($requestBody, $response, 200);
     }
 
 

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -14,6 +14,7 @@ services:
     - BrandEmbassyTest\Slim\Sample\BeforeRouteMiddleware
     - BrandEmbassyTest\Slim\Sample\AfterRouteMiddleware
     - BrandEmbassyTest\Slim\Sample\CreateChannelUserRoute
+    - BrandEmbassyTest\Slim\Sample\EchoParsedBodyRoute
     - BrandEmbassyTest\Slim\Sample\GroupMiddleware
     - BrandEmbassyTest\Slim\Sample\OnlyApiGroupMiddleware
     helloWorldRoute: BrandEmbassyTest\Slim\Sample\HelloWorldRoute
@@ -61,6 +62,12 @@ slimApi:
                 post:
                     name: getChannelUsers
                     service: BrandEmbassyTest\Slim\Sample\CreateChannelUserRoute
+                    middlewareGroups:
+                        - testGroup
+
+            '/echo-body':
+                put:
+                    service: BrandEmbassyTest\Slim\Sample\EchoParsedBodyRoute
                     middlewareGroups:
                         - testGroup
 


### PR DESCRIPTION
## Summary
- Adds `addBodyParsingMiddleware()` to `SlimApplicationFactory::create()`
- Slim 3 automatically parsed JSON request bodies, but Slim 4 requires explicit `BodyParsingMiddleware`
- Without it, `getParsedBody()` returns `null` for JSON requests, causing validators like `NotEmptyBodyMiddleware` to reject valid JSON bodies with "Body must not be empty and must be valid JSON"

## Root Cause
QA reported 400 errors on PUT/POST endpoints with valid JSON bodies. The `NotEmptyBodyMiddleware` calls `$request->getParsedBody()` which returned `null` because Slim 4 doesn't auto-parse JSON bodies like Slim 3 did.

## Test Plan
- [x] Verified `BodyParsingMiddleware` is a built-in Slim 4 middleware
- [ ] Run integration tests to confirm JSON body parsing works
- [ ] Verify PUT/POST endpoints accept valid JSON bodies in QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)