### PR TITLE
DE-162056: Skip rawurldecode to preserve all encoded chars in route params

### DIFF
--- a/src/Routing/NonDecodingRouteResolver.php
+++ b/src/Routing/NonDecodingRouteResolver.php
@@ -20,7 +20,7 @@ use Slim\Routing\RoutingResults;
  * This resolver matches Slim 3's behavior: the URI is passed to FastRoute as-is,
  * preserving all percent-encoded characters in route parameters.
  */
-class SlashSafeRouteResolver extends RouteResolver
+class NonDecodingRouteResolver extends RouteResolver
 {
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {

--- a/src/Routing/SlashSafeRouteResolver.php
+++ b/src/Routing/SlashSafeRouteResolver.php
@@ -12,9 +12,10 @@ use Slim\Routing\RoutingResults;
  * Custom RouteResolver that skips rawurldecode() on the URI before dispatching.
  *
  * Slim 4's default RouteResolver calls rawurldecode() on the URI before dispatching
- * to FastRoute. This decodes percent-encoded characters (%2F, %3A, %2B, etc.) into
- * their literal forms, which breaks route matching for parameters containing encoded
- * special characters (e.g. base64-encoded URN identifiers).
+ * to FastRoute. This decodes percent-encoded characters (%2F, %3A, %2B, %3D, etc.)
+ * into their literal forms. Decoding %2F into "/" can change path segmentation and
+ * thus break route matching; decoding other characters can corrupt the values of
+ * matched route parameters (e.g. base64-encoded or URN-like identifiers).
  *
  * This resolver matches Slim 3's behavior: the URI is passed to FastRoute as-is,
  * preserving all percent-encoded characters in route parameters.

--- a/src/Routing/SlashSafeRouteResolver.php
+++ b/src/Routing/SlashSafeRouteResolver.php
@@ -5,54 +5,28 @@ namespace BrandEmbassy\Slim\Routing;
 use Slim\Routing\Dispatcher;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RoutingResults;
-use function preg_match;
-use function preg_replace_callback;
-use function rawurldecode;
 
 /**
  * @final
  *
- * Custom RouteResolver that preserves %2F (encoded forward slashes) in URI paths.
+ * Custom RouteResolver that skips rawurldecode() on the URI before dispatching.
  *
  * Slim 4's default RouteResolver calls rawurldecode() on the URI before dispatching
- * to FastRoute. This decodes %2F into literal /, which breaks route matching for
- * parameters containing encoded slashes (e.g. base64-encoded identifiers).
+ * to FastRoute. This decodes percent-encoded characters (%2F, %3A, %2B, etc.) into
+ * their literal forms, which breaks route matching for parameters containing encoded
+ * special characters (e.g. base64-encoded URN identifiers).
  *
- * This resolver decodes all percent-encoded triplets except %2F, so FastRoute
- * sees %2F as part of the segment — not as a path separator.
+ * This resolver matches Slim 3's behavior: the URI is passed to FastRoute as-is,
+ * preserving all percent-encoded characters in route parameters.
  */
 class SlashSafeRouteResolver extends RouteResolver
 {
-    private const ENCODED_SLASH_PATTERN = '/%2f/i';
-
-
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {
-        $uri = $this->rawurldecodeSafe($uri);
-
         if ($uri === '' || $uri[0] !== '/') {
             $uri = '/' . $uri;
         }
 
         return (new Dispatcher($this->routeCollector))->dispatch($method, $uri);
-    }
-
-
-    /**
-     * Decodes all percent-encoded triplets except %2F (encoded forward slash).
-     */
-    private function rawurldecodeSafe(string $uri): string
-    {
-        return (string)preg_replace_callback(
-            '/%[0-9A-Fa-f]{2}/',
-            static function (array $match): string {
-                if (preg_match(self::ENCODED_SLASH_PATTERN, $match[0]) === 1) {
-                    return $match[0];
-                }
-
-                return rawurldecode($match[0]);
-            },
-            $uri,
-        );
     }
 }

--- a/src/SlimApplicationFactory.php
+++ b/src/SlimApplicationFactory.php
@@ -6,7 +6,7 @@ use BrandEmbassy\Slim\DI\ServiceProvider;
 use BrandEmbassy\Slim\Middleware\MiddlewareFactory;
 use BrandEmbassy\Slim\Route\OnlyNecessaryRoutesProvider;
 use BrandEmbassy\Slim\Route\RouteRegister;
-use BrandEmbassy\Slim\Routing\SlashSafeRouteResolver;
+use BrandEmbassy\Slim\Routing\NonDecodingRouteResolver;
 use LogicException;
 use Nette\DI\Container;
 use Slim\CallableResolver;
@@ -94,7 +94,7 @@ class SlimApplicationFactory
             $slimContainer,
             null,
             $routeCollector,
-            new SlashSafeRouteResolver($routeCollector),
+            new NonDecodingRouteResolver($routeCollector),
         );
 
         $this->registerRoutes($slimApp);

--- a/tests/Routing/NonDecodingRouteResolverTest.php
+++ b/tests/Routing/NonDecodingRouteResolverTest.php
@@ -2,7 +2,7 @@
 
 namespace BrandEmbassyTest\Slim\Routing;
 
-use BrandEmbassy\Slim\Routing\SlashSafeRouteResolver;
+use BrandEmbassy\Slim\Routing\NonDecodingRouteResolver;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -16,7 +16,7 @@ use Slim\Routing\RoutingResults;
 /**
  * @final
  */
-class SlashSafeRouteResolverTest extends TestCase
+class NonDecodingRouteResolverTest extends TestCase
 {
     /**
      * @dataProvider provideMatchingUriCases
@@ -97,14 +97,14 @@ class SlashSafeRouteResolverTest extends TestCase
 
         Assert::assertSame(RoutingResults::NOT_FOUND, $defaultResult->getRouteStatus());
 
-        $safeResult = (new SlashSafeRouteResolver($routeCollector))
+        $safeResult = (new NonDecodingRouteResolver($routeCollector))
             ->computeRoutingResults('/items/abc%2Fdef', 'GET');
 
         Assert::assertSame(RoutingResults::FOUND, $safeResult->getRouteStatus());
     }
 
 
-    private function createResolverWithRoute(string $method, string $pattern): SlashSafeRouteResolver
+    private function createResolverWithRoute(string $method, string $pattern): NonDecodingRouteResolver
     {
         $responseFactory = new ResponseFactory();
         $callableResolver = new CallableResolver();
@@ -112,7 +112,7 @@ class SlashSafeRouteResolverTest extends TestCase
 
         $routeCollector->map([$method], $pattern, $this->createDummyHandler());
 
-        return new SlashSafeRouteResolver($routeCollector);
+        return new NonDecodingRouteResolver($routeCollector);
     }
 
 

--- a/tests/Routing/SlashSafeRouteResolverTest.php
+++ b/tests/Routing/SlashSafeRouteResolverTest.php
@@ -21,7 +21,7 @@ class SlashSafeRouteResolverTest extends TestCase
     /**
      * @dataProvider provideMatchingUriCases
      */
-    public function testRouteWithEncodedSlashIsMatched(string $uri, string $expectedRawParamValue): void
+    public function testRouteIsMatchedAndParameterPreserved(string $uri, string $expectedRawParamValue): void
     {
         $resolver = $this->createResolverWithRoute('GET', '/items/{id}');
 
@@ -42,29 +42,33 @@ class SlashSafeRouteResolverTest extends TestCase
                 '/items/simple',
                 'simple',
             ],
-            'encoded slash %2F preserved in parameter' => [
+            'encoded slash %2F preserved' => [
                 '/items/abc%2Fdef',
                 'abc%2Fdef',
             ],
-            'encoded slash %2f lowercase preserved as-is' => [
-                '/items/abc%2fdef',
-                'abc%2fdef',
+            'encoded colon %3A preserved' => [
+                '/items/urn%3Ambid%3Avalue',
+                'urn%3Ambid%3Avalue',
             ],
-            'other percent-encoded chars decoded normally' => [
+            'encoded plus %2B preserved' => [
+                '/items/abc%2Bdef',
+                'abc%2Bdef',
+            ],
+            'encoded space %20 preserved' => [
                 '/items/hello%20world',
-                'hello world',
+                'hello%20world',
             ],
-            'mixed encoded slash and space' => [
-                '/items/abc%2Fdef%20ghi',
-                'abc%2Fdef ghi',
+            'encoded equals %3D preserved' => [
+                '/items/base64value%3D',
+                'base64value%3D',
+            ],
+            'complex URN with multiple encoded chars preserved' => [
+                '/items/urn%3Ambid%3AAQAAY4PwoYv7H0b8%2B6Zx7WkS%2BjV%2FzkJMyh9xoms0%3D',
+                'urn%3Ambid%3AAQAAY4PwoYv7H0b8%2B6Zx7WkS%2BjV%2FzkJMyh9xoms0%3D',
             ],
             'multiple encoded slashes preserved' => [
                 '/items/a%2Fb%2Fc',
                 'a%2Fb%2Fc',
-            ],
-            'encoded curly braces decoded normally' => [
-                '/items/%7B%7Bsome-value%7D%7D',
-                '{{some-value}}',
             ],
         ];
     }


### PR DESCRIPTION
Description: Skip rawurldecode entirely in route resolution to preserve all percent-encoded characters
Possible impact: Route matching for parameters containing any percent-encoded characters (URN IDs, base64 values)

---

## Summary
- Simplifies `SlashSafeRouteResolver` to skip `rawurldecode()` entirely, matching Slim 3 behavior
- Previous fix (6.0.4) only preserved `%2F` — but real URN identifiers also contain `%3A` (`:`), `%2B` (`+`), `%3D` (`=`), etc.
- All percent-encoded characters now pass through to FastRoute unchanged

## Problem
The 6.0.4 fix preserved only `%2F` via `preg_replace_callback`. But Apple Business URN IDs like:
```
urn%3Ambid%3AAQAAY4PwoYv7H0b8%2B6Zx7WkS%2BjV%2FzkJMyh9xoms0%3D
```
contain `%3A`, `%2B`, `%3D` which were all still being decoded into `:`, `+`, `=`, corrupting the parameter value.

## Solution
Skip `rawurldecode()` entirely — Slim 3 never decoded the URI before FastRoute dispatch. This is the simplest and most correct approach.

## Test plan
- [x] 10 unit tests covering encoded slashes, colons, plus signs, equals, complex URNs
- [x] Integration test for `%2F` in route param
- [x] PHPStan level 8 clean
- [x] Full test suite passes (35 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)